### PR TITLE
New test case added - Check if user try to register already registered email

### DIFF
--- a/Fortrade_landing_pages/TestNG.xml
+++ b/Fortrade_landing_pages/TestNG.xml
@@ -2,83 +2,59 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
 
 <suite name="Landing Pages">
-    <test name="Check link redirections - FSC regulative">
+    <test name="Check if user try to register already registered account">
         <parameter name="countryCodeNumber" value="381"/>
-        <parameter name="regulative" value="FSC"/>
-        <parameter name="regulation" value="fsc"/>
-        <parameter name="tag" value="?tg=skip&amp;G_GEO=2051&amp;regulation=FSC"/>
         <classes>
+            <class name="Tests.RegistrationTestLp1">
+                <methods>
+                    <include name="userExist"/>
+                </methods>
+            </class>
+            <class name="Tests.RegistrationTestLp2">
+                <methods>
+                    <include name="userExist"/>
+                </methods>
+            </class>
+            <class name="Tests.RegistrationTestLp3">
+                <methods>
+                    <include name="userExist"/>
+                </methods>
+            </class>
+            <class name="Tests.RegistrationTestLp4">
+                <methods>
+                    <include name="userExist"/>
+                </methods>
+            </class>
             <class name="Tests.RegistrationTestLp5">
                 <methods>
-                    <include name="checkRiskWarningLinkRedirection"/>
-                    <include name="checkPrivacyPolicyLinkRedirection"/>
-                    <include name="checkTermsAndConditionsLinkRedirection"/>
-                    <include name="checkFSCLinkRedirection"/>
-                    <include name="checkHowToUnsubscribeLinkRedirection"/>
+                    <include name="userExist"/>
+                </methods>
+            </class>
+            <class name="Tests.RegistrationTestLp6">
+                <methods>
+                    <include name="userExist"/>
+                </methods>
+            </class>
+            <class name="Tests.RegistrationTestLp7">
+                <methods>
+                    <include name="userExist"/>
+                </methods>
+            </class>
+            <class name="Tests.RegistrationTestLp8">
+                <methods>
+                    <include name="userExist"/>
+                </methods>
+            </class>
+            <class name="Tests.RegistrationTestLp9">
+                <methods>
+                    <include name="userExist"/>
+                </methods>
+            </class>
+            <class name="Tests.RegistrationTestLp10">
+                <methods>
+                    <include name="userExist"/>
                 </methods>
             </class>
         </classes>
     </test>
-        <test name="Check link redirections - FCA regulative">
-            <parameter name="countryCodeNumber" value="44"/>
-            <parameter name="regulative" value="FCA"/>
-            <parameter name="regulation" value="fca"/>
-            <parameter name="tag" value="?tg=skip&amp;G_GEO=1006453&amp;regulation=FCA"/>
-            <classes>
-                <class name="Tests.RegistrationTestLp5">
-                    <methods>
-                        <include name="checkRiskWarningLinkRedirection"/>
-                        <include name="checkPrivacyPolicyLinkRedirection"/>
-                        <include name="checkTermsAndConditionsLinkRedirection"/>
-                        <include name="checkFCALinkRedirection"/>
-                    </methods>
-                </class>
-            </classes>
-        </test>
-    <test name="Check link redirections - cysec regulative">
-        <parameter name="countryCodeNumber" value="357"/>
-        <parameter name="regulative" value="cysec"/>
-        <parameter name="regulation" value="cysec"/>
-        <parameter name="tag" value="?tg=skip&amp;G_GEO=1000997&amp;regulation=CYSEC"/>
-        <classes>
-            <class name="Tests.RegistrationTestLp5">
-                <methods>
-                    <include name="checkRiskWarningLinkRedirection"/>
-                    <include name="checkPrivacyPolicyLinkRedirection"/>
-                    <include name="checkTermsAndConditionsLinkRedirection"/>
-                    <include name="checkCysecLinkRedirection"/>
-                </methods>
-            </class>
-        </classes>
-    </test>
-    <test name="Check link redirections - Asic regulative">
-        <parameter name="countryCodeNumber" value="61"/>
-        <parameter name="regulative" value="Asic"/>
-        <parameter name="regulation" value="asic"/>
-        <parameter name="tag" value="?tg=skip&amp;G_GEO=1000142&amp;regulation=ASIC"/>
-        <classes>
-            <class name="Tests.RegistrationTestLp5">
-                <methods>
-                    <include name="checkRiskWarningLinkRedirection"/>
-                    <include name="checkAsicLinkRedirection"/>
-                </methods>
-            </class>
-        </classes>
-    </test>
-        <test name="Check link redirections - Iiroc regulative">
-            <parameter name="countryCodeNumber" value="1"/>
-            <parameter name="regulative" value="iiroc"/>
-            <parameter name="regulation" value="iiroc"/>
-            <parameter name="tag" value="?tg=skip&amp;G_GEO=9077369&amp;regulation=IIROC"/>
-            <classes>
-                <class name="Tests.RegistrationTestLp5">
-                    <methods>
-                        <include name="checkRiskWarningLinkRedirection"/>
-                        <include name="checkPrivacyPolicyLinkRedirection"/>
-                        <include name="checkTermsAndConditionsLinkRedirection"/>
-                        <include name="checkIirocLinkRedirection"/>
-                    </methods>
-                </class>
-            </classes>
-        </test>
 </suite>

--- a/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp1.java
+++ b/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp1.java
@@ -52,6 +52,55 @@ public class RegistrationTestLp1 extends BaseTest {
         Assert.assertEquals(regulativeValue, regulative);
         new BasePage(driver).reportScreenshot("Screenshot " + regulative + " regulative");
     }
+    @Test(description = "Check if user is already registered")
+    @Description("User try to register already registered account")
+    @Parameters({"countryCodeNumber"})
+    public void userExist(String countryCodeNumber) throws IOException {
+        /**
+         navigate to the landing page - driver.get() is triggered from setUp method
+         */
+               AccountRegistrationPage accountRegistrationPage = new AccountRegistrationPage(driver);
+        /**
+        *register new account
+        */
+        accountRegistrationPage.accountRegistrationMethod("Testq","Testa",
+                "test"+System.currentTimeMillis()+"@mailinator.com",""+countryCodeNumber,
+                ""+System.currentTimeMillis());
+        WebDriverWait wdWait = new WebDriverWait(driver,10);
+        /**
+         *save the email address used during account registration
+         */
+        wdWait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='credetialsBox']//span" +
+                "[@id='loginUserEmail']")));
+        WebElement email = driver.findElement(By.xpath("//div[@class='credetialsBox']//span[@id='loginUserEmail']"));
+        String emailAddress = email.getText();
+        driver.close();
+        /**
+         * navigate to the same landing page in the new window
+         */
+        baseSetUp("CHROME","114");
+        driver.get("https://www.fortrade.com/minilps/en/reg-to-invest-in-stocks-only-work-with-the-best/");
+        /**
+         * try to register account by using email address from previous registration (already registered email address)
+         */
+        AccountRegistrationPage accountRegistrationPage1 = new AccountRegistrationPage(driver);
+        accountRegistrationPage1.accountRegistrationMethod("Testq","Testa",emailAddress,countryCodeNumber,
+                ""+System.currentTimeMillis());
+        /**
+         * check if user exist pop up appears and verify the same
+         */
+        WebDriverWait wait = new WebDriverWait(driver,5);
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//label[@name='UserExistLabel']")));
+        WebElement userExistWindow = driver.findElement(By.xpath("//label[@name='UserExistLabel']"));
+        userExistWindow.isDisplayed();
+        if(userExistWindow.isDisplayed()==true){
+            System.out.println("'It looks like you've already got an account associated with this email/phone. Log in instead or " +
+                    " reset your password if you've forgotten it.' pop up window is displayed ");
+        }
+        //taking screenshot
+        new BasePage(driver).reportScreenshot("User exist window is displayed");
+        tearDown();
+    }
 
     @Test(description = "Confirm validation messages")
     @Description("Appropriate error messages are triggered if user doesn't insert data")

--- a/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp10.java
+++ b/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp10.java
@@ -51,6 +51,55 @@ public class RegistrationTestLp10 extends BaseTest {
         Assert.assertEquals(regulativeValue, regulative);
         new BasePage(driver).reportScreenshot("Screenshot " + regulative + " regulative");
     }
+    @Test(description = "Check if user is already registered")
+    @Description("User try to register already registered account")
+    @Parameters({"countryCodeNumber"})
+    public void userExist(String countryCodeNumber) throws IOException {
+        /**
+         navigate to the landing page - driver.get() is triggered from setUp method
+         */
+        AccountRegistrationPage accountRegistrationPage = new AccountRegistrationPage(driver);
+        /**
+         *register new account
+         */
+        accountRegistrationPage.accountRegistrationMethod("Testq","Testa",
+                "test"+System.currentTimeMillis()+"@mailinator.com",""+countryCodeNumber,
+                ""+System.currentTimeMillis());
+        WebDriverWait wdWait = new WebDriverWait(driver,10);
+        /**
+         *save the email address used during account registration
+         */
+        wdWait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='credetialsBox']//span" +
+                "[@id='loginUserEmail']")));
+        WebElement email = driver.findElement(By.xpath("//div[@class='credetialsBox']//span[@id='loginUserEmail']"));
+        String emailAddress = email.getText();
+        driver.close();
+        /**
+         * navigate to the same landing page in the new window
+         */
+        baseSetUp("CHROME","114");
+        driver.get("https://www.fortrade.com/minilps/en/opportunities-to-trade-on-oil-are-gushing-at-fortrade/");
+        /**
+         * try to register account by using email address from previous registration (already registered email address)
+         */
+        AccountRegistrationPage accountRegistrationPage1 = new AccountRegistrationPage(driver);
+        accountRegistrationPage1.accountRegistrationMethod("Testq","Testa",emailAddress,countryCodeNumber,
+                ""+System.currentTimeMillis());
+        /**
+         * check if user exist pop up appears and verify the same
+         */
+        WebDriverWait wait = new WebDriverWait(driver,5);
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//label[@name='UserExistLabel']")));
+        WebElement userExistWindow = driver.findElement(By.xpath("//label[@name='UserExistLabel']"));
+        userExistWindow.isDisplayed();
+        if(userExistWindow.isDisplayed()==true){
+            System.out.println("'It looks like you've already got an account associated with this email/phone. Log in instead or " +
+                    " reset your password if you've forgotten it.' pop up window is displayed ");
+        }
+        //taking screenshot
+        new BasePage(driver).reportScreenshot("User exist window is displayed");
+        tearDown();
+    }
     @Test(description ="Confirm validation messages")
     @Description("Appropriate error messages are triggered if user doesn't insert data")
     public void fieldsValidation() throws IOException {

--- a/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp2.java
+++ b/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp2.java
@@ -1,6 +1,7 @@
 package Tests;
 
 import Pages.AccountRegistrationFullNamePage;
+import Pages.AccountRegistrationPage;
 import Pages.BasePage;
 import jdk.jfr.Description;
 import org.openqa.selenium.By;
@@ -50,6 +51,55 @@ public class RegistrationTestLp2 extends BaseTest {
         //Verifying they are matching
         Assert.assertEquals(regulativeValue, regulative);
         new BasePage(driver).reportScreenshot("Screenshot " + regulative + " regulative");
+    }
+    @Test(description = "Check if user is already registered")
+    @Description("User try to register already registered account")
+    @Parameters({"countryCodeNumber"})
+    public void userExist(String countryCodeNumber) throws IOException {
+        /**
+         * navigate to the landing page - driver.get() is triggered from setUp method
+         */
+        AccountRegistrationFullNamePage accountRegistrationFullNamePage = new AccountRegistrationFullNamePage(driver);
+        /**
+         *register new account
+         */
+        accountRegistrationFullNamePage.accountRegistrationFullNamePageMethod("Testq Testa", "test"
+                        + System.currentTimeMillis() + "@mailinator.com",countryCodeNumber + "",
+                "" + System.currentTimeMillis());
+        WebDriverWait wdWait = new WebDriverWait(driver,10);
+        /**
+         *save the email address used during account registration
+         */
+        wdWait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='credetialsBox']//span" +
+                "[@id='loginUserEmail']")));
+        WebElement email = driver.findElement(By.xpath("//div[@class='credetialsBox']//span[@id='loginUserEmail']"));
+        String emailAddress = email.getText();
+        driver.close();
+        /**
+         * navigate to the same landing page in the new window
+         */
+        baseSetUp("CHROME","114");
+        driver.get("https://www.fortrade.com/minilps/en/inst-oil/");
+        /**
+         * try to register account by using email address from previous registration (already registered email address)
+         */
+        AccountRegistrationFullNamePage accountRegistrationFullNamePage1 = new AccountRegistrationFullNamePage(driver);
+        accountRegistrationFullNamePage1.accountRegistrationFullNamePageMethod("Testq Testa",emailAddress,
+                countryCodeNumber,""+System.currentTimeMillis());
+        /**
+         * check if user exist pop up appears and verify the same
+         */
+        WebDriverWait wait = new WebDriverWait(driver,5);
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//label[@name='UserExistLabel']")));
+        WebElement userExistWindow = driver.findElement(By.xpath("//label[@name='UserExistLabel']"));
+        userExistWindow.isDisplayed();
+        if(userExistWindow.isDisplayed()==true){
+            System.out.println("'It looks like you've already got an account associated with this email/phone. Log in instead or " +
+                    " reset your password if you've forgotten it.' pop up window is displayed ");
+        }
+        //taking screenshot
+        new BasePage(driver).reportScreenshot("User exist window is displayed");
+        tearDown();
     }
     @Test(description = "Confirm validation messages")
     @Description("Appropriate error messages are triggered if user doesn't insert data")

--- a/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp3.java
+++ b/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp3.java
@@ -51,7 +51,55 @@ public class RegistrationTestLp3 extends BaseTest {
             Assert.assertEquals(regulativeValue,regulative);
             new BasePage(driver).reportScreenshot("Screenshot "+regulative+" regulative");
     }
-
+    @Test(description = "Check if user is already registered")
+    @Description("User try to register already registered account")
+    @Parameters({"countryCodeNumber"})
+    public void userExist(String countryCodeNumber) throws IOException {
+        /**
+         * navigate to the landing page - driver.get() is triggered from setUp method
+         */
+        AccountRegistrationFullNamePage accountRegistrationFullNamePage = new AccountRegistrationFullNamePage(driver);
+        /**
+         *register new account
+         */
+        accountRegistrationFullNamePage.accountRegistrationFullNamePageMethod("Testq Testa", "test"
+                        + System.currentTimeMillis() + "@mailinator.com",countryCodeNumber + "",
+                "" + System.currentTimeMillis());
+        WebDriverWait wdWait = new WebDriverWait(driver,10);
+        /**
+         *save the email address used during account registration
+         */
+        wdWait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='credetialsBox']//span" +
+                "[@id='loginUserEmail']")));
+        WebElement email = driver.findElement(By.xpath("//div[@class='credetialsBox']//span[@id='loginUserEmail']"));
+        String emailAddress = email.getText();
+        driver.close();
+        /**
+         * navigate to the same landing page in the new window
+         */
+        baseSetUp("CHROME","114");
+        driver.get("https://www.fortrade.com/minilps/en/trading-shares-is-at-your-fingertips/");
+        /**
+         * try to register account by using email address from previous registration (already registered email address)
+         */
+        AccountRegistrationFullNamePage accountRegistrationFullNamePage1 = new AccountRegistrationFullNamePage(driver);
+        accountRegistrationFullNamePage1.accountRegistrationFullNamePageMethod("Testq Testa",emailAddress,
+                countryCodeNumber,""+System.currentTimeMillis());
+        /**
+         * check if user exist pop up appears and verify the same
+         */
+        WebDriverWait wait = new WebDriverWait(driver,5);
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//label[@name='UserExistLabel']")));
+        WebElement userExistWindow = driver.findElement(By.xpath("//label[@name='UserExistLabel']"));
+        userExistWindow.isDisplayed();
+        if(userExistWindow.isDisplayed()==true){
+            System.out.println("'It looks like you've already got an account associated with this email/phone. Log in instead or " +
+                    " reset your password if you've forgotten it.' pop up window is displayed ");
+        }
+        //taking screenshot
+        new BasePage(driver).reportScreenshot("User exist window is displayed");
+        tearDown();
+    }
     @Test(description = "Confirm validation messages")
     @Description("Appropriate error messages are triggered if user doesn't insert data")
     public void fieldsValidation() throws IOException {

--- a/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp4.java
+++ b/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp4.java
@@ -53,6 +53,56 @@ public class RegistrationTestLp4 extends BaseTest {
         Assert.assertEquals(regulativeValue, regulative);
         new BasePage(driver).reportScreenshot("Screenshot " + regulative + " regulative");
     }
+    @Test(description = "Check if user is already registered")
+    @Description("User try to register already registered account")
+    @Parameters({"countryCodeNumber"})
+    public void userExist(String countryCodeNumber) throws IOException {
+        /**
+         * navigate to the landing page - driver.get() is triggered from setUp method
+         */
+        AccountRegistrationPage accountRegistrationPage = new AccountRegistrationPage(driver);
+        /**
+         *register new account
+         */
+        accountRegistrationPage.accountRegistrationMethod("Testq","Testa",
+                "test"+System.currentTimeMillis()+"@mailinator.com",""+countryCodeNumber,
+                ""+System.currentTimeMillis());
+        WebDriverWait wdWait = new WebDriverWait(driver,10);
+        /**
+         *save the email address used during account registration
+         */
+        wdWait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='credetialsBox']//span" +
+                "[@id='loginUserEmail']")));
+        WebElement email = driver.findElement(By.xpath("//div[@class='credetialsBox']//span[@id='loginUserEmail']"));
+        String emailAddress = email.getText();
+        driver.close();
+        /**
+         * navigate to the same landing page in the new window
+         */
+        baseSetUp("CHROME","114");
+        driver.get("https://www.fortrade.com/minilps/en/cryptocurrency/");
+        /**
+         * try to register account by using email address from previous registration (already registered email address)
+         */
+        AccountRegistrationPage accountRegistrationPage1 = new AccountRegistrationPage(driver);
+        accountRegistrationPage1.accountRegistrationMethod("Testq","Testa",emailAddress,countryCodeNumber,
+                ""+System.currentTimeMillis());
+        /**
+         * check if user exist pop up appears and verify the same
+         */
+        WebDriverWait wait = new WebDriverWait(driver,5);
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//label[@name='UserExistLabel']")));
+        WebElement userExistWindow = driver.findElement(By.xpath("//label[@name='UserExistLabel']"));
+        userExistWindow.isDisplayed();
+        if(userExistWindow.isDisplayed()==true){
+            System.out.println("'It looks like you've already got an account associated with this email/phone. Log in instead or " +
+                    " reset your password if you've forgotten it.' pop up window is displayed ");
+        }
+        //taking screenshot
+        new BasePage(driver).reportScreenshot("User exist window is displayed");
+        tearDown();
+    }
+
     @Test(description ="Confirm validation messages")
     @Description("Appropriate error messages are triggered if user doesn't insert data")
     public void fieldsValidation() throws IOException {

--- a/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp5.java
+++ b/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp5.java
@@ -51,7 +51,56 @@ public class RegistrationTestLp5 extends BaseTest {
         Assert.assertEquals(regulativeValue, regulative);
         new BasePage(driver).reportScreenshot("Screenshot " + regulative + " regulative");
     }
-
+    @Test(description = "Check if user is already registered")
+    @Description("User try to register already registered account")
+    @Parameters({"countryCodeNumber"})
+    public void userExist(String countryCodeNumber) throws IOException {
+        /**
+         *  navigate to the landing page - driver.get() is triggered from setUp method
+         */
+        AccountRegistrationFullNamePage accountRegistrationFullNamePage = new AccountRegistrationFullNamePage(driver);
+        /**
+         *register new account
+         */
+        accountRegistrationFullNamePage.accountRegistrationFullNamePageMethod("Testq Testa", "test"
+                        + System.currentTimeMillis() + "@mailinator.com",countryCodeNumber + "",
+                "" + System.currentTimeMillis());
+        WebDriverWait wdWait = new WebDriverWait(driver,10);
+        /**
+         *save the email address used during account registration
+         */
+        wdWait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='credetialsBox']//span" +
+                "[@id='loginUserEmail']")));
+        WebElement email = driver.findElement(By.xpath("//div[@class='credetialsBox']//span[@id='loginUserEmail']"));
+        String emailAddress = email.getText();
+        System.out.println(emailAddress);
+        driver.close();
+        /**
+         * navigate to the same landing page in the new window
+         */
+        baseSetUp("CHROME","114");
+        driver.get("https://www.fortrade.com/minilps/en/invest-together-vid/");
+        /**
+         * try to register account by using email address from previous registration (already registered email address)
+         */
+        AccountRegistrationFullNamePage accountRegistrationFullNamePage1 = new AccountRegistrationFullNamePage(driver);
+        accountRegistrationFullNamePage1.accountRegistrationFullNamePageMethod("Testq Testa",emailAddress,
+                countryCodeNumber,""+System.currentTimeMillis());
+        /**
+         * check if user exist pop up appears and verify the same
+         */
+        WebDriverWait wait = new WebDriverWait(driver,5);
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//label[@name='UserExistLabel']")));
+        WebElement userExistWindow = driver.findElement(By.xpath("//label[@name='UserExistLabel']"));
+        userExistWindow.isDisplayed();
+        if(userExistWindow.isDisplayed()==true){
+            System.out.println("'It looks like you've already got an account associated with this email/phone. Log in instead or " +
+                    " reset your password if you've forgotten it.' pop up window is displayed ");
+        }
+        //taking screenshot
+        new BasePage(driver).reportScreenshot("User exist window is displayed");
+        tearDown();
+    }
     @Test(description = "Confirm validation messages")
     @Description("Appropriate error messages are triggered if user doesn't insert data")
     public void fieldsValidation() throws IOException {

--- a/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp6.java
+++ b/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp6.java
@@ -54,6 +54,56 @@ public class RegistrationTestLp6 extends BaseTest {
         Assert.assertEquals(regulativeValue, regulative);
         new BasePage(driver).reportScreenshot("Screenshot " + regulative + " regulative");
     }
+    @Test(description = "Check if user is already registered")
+    @Description("User try to register already registered account")
+    @Parameters({"countryCodeNumber"})
+    public void userExist(String countryCodeNumber) throws IOException {
+        /**
+         *navigate to the landing page - driver.get() is triggered from setUp method
+         */
+        AccountRegistrationFullNamePage accountRegistrationFullNamePage = new AccountRegistrationFullNamePage(driver);
+        /**
+         *register new account
+         */
+        accountRegistrationFullNamePage.accountRegistrationFullNamePageMethod("Testq Testa", "test"
+                        + System.currentTimeMillis() + "@mailinator.com",countryCodeNumber + "",
+                "" + System.currentTimeMillis());
+        WebDriverWait wdWait = new WebDriverWait(driver,10);
+        /**
+         *save the email address used during account registration
+         */
+        wdWait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='credetialsBox']//span" +
+                "[@id='loginUserEmail']")));
+        WebElement email = driver.findElement(By.xpath("//div[@class='credetialsBox']//span[@id='loginUserEmail']"));
+        String emailAddress = email.getText();
+        System.out.println(emailAddress);
+        driver.close();
+        /**
+         * navigate to the same landing page in the new window
+         */
+        baseSetUp("CHROME","114");
+        driver.get("https://www.fortrade.com/minilps/en/when-you-jump-into-online-trading-be-smart-about-it/");
+        /**
+         * try to register account by using email address from previous registration (already registered email address)
+         */
+        AccountRegistrationFullNamePage accountRegistrationFullNamePage1 = new AccountRegistrationFullNamePage(driver);
+        accountRegistrationFullNamePage1.accountRegistrationFullNamePageMethod("Testq Testa",emailAddress,
+                countryCodeNumber,""+System.currentTimeMillis());
+        /**
+         * check if user exist pop up appears and verify the same
+         */
+        WebDriverWait wait = new WebDriverWait(driver,5);
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//label[@name='UserExistLabel']")));
+        WebElement userExistWindow = driver.findElement(By.xpath("//label[@name='UserExistLabel']"));
+        userExistWindow.isDisplayed();
+        if(userExistWindow.isDisplayed()==true){
+            System.out.println("'It looks like you've already got an account associated with this email/phone. Log in instead or " +
+                    " reset your password if you've forgotten it.' pop up window is displayed ");
+        }
+        //taking screenshot
+        new BasePage(driver).reportScreenshot("User exist window is displayed");
+        tearDown();
+    }
     @Test(description ="Confirm validation messages")
     @Description("Appropriate error messages are triggered if user doesn't insert data")
     public void fieldsValidation() throws IOException {

--- a/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp7.java
+++ b/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp7.java
@@ -50,6 +50,55 @@ public class RegistrationTestLp7 extends BaseTest {
         Assert.assertEquals(regulativeValue, regulative);
         new BasePage(driver).reportScreenshot("Screenshot " + regulative + " regulative");
     }
+    @Test(description = "Check if user is already registered")
+    @Description("User try to register already registered account")
+    @Parameters({"countryCodeNumber"})
+    public void userExist(String countryCodeNumber) throws IOException {
+        /**
+         *navigate to the landing page - driver.get() is triggered from setUp method
+         */
+        AccountRegistrationPage accountRegistrationPage = new AccountRegistrationPage(driver);
+        /**
+         *register new account
+         */
+        accountRegistrationPage.accountRegistrationMethod("Testq","Testa",
+                "test"+System.currentTimeMillis()+"@mailinator.com",""+countryCodeNumber,
+                ""+System.currentTimeMillis());
+        WebDriverWait wdWait = new WebDriverWait(driver,10);
+        /**
+         *save the email address used during account registration
+         */
+        wdWait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='credetialsBox']//span" +
+                "[@id='loginUserEmail']")));
+        WebElement email = driver.findElement(By.xpath("//div[@class='credetialsBox']//span[@id='loginUserEmail']"));
+        String emailAddress = email.getText();
+        driver.close();
+        /**
+         * navigate to the same landing page in the new window
+         */
+        baseSetUp("CHROME","114");
+        driver.get("https://www.fortrade.com/minilps/en/reg-trade-opportunities-can-glitter-like-gold-at-fortrade/");
+        /**
+         * try to register account by using email address from previous registration (already registered email address)
+         */
+        AccountRegistrationPage accountRegistrationPage1 = new AccountRegistrationPage(driver);
+        accountRegistrationPage1.accountRegistrationMethod("Testq","Testa",emailAddress,countryCodeNumber,
+                ""+System.currentTimeMillis());
+        /**
+         * check if user exist pop up appears and verify the same
+         */
+        WebDriverWait wait = new WebDriverWait(driver,5);
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//label[@name='UserExistLabel']")));
+        WebElement userExistWindow = driver.findElement(By.xpath("//label[@name='UserExistLabel']"));
+        userExistWindow.isDisplayed();
+        if(userExistWindow.isDisplayed()==true){
+            System.out.println("'It looks like you've already got an account associated with this email/phone. Log in instead or " +
+                    " reset your password if you've forgotten it.' pop up window is displayed ");
+        }
+        //taking screenshot
+        new BasePage(driver).reportScreenshot("User exist window is displayed");
+        tearDown();
+    }
 
     @Test(description = "Confirm validation messages")
     @Description("Appropriate error messages are triggered if user doesn't insert data")

--- a/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp8.java
+++ b/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp8.java
@@ -52,6 +52,56 @@ public class RegistrationTestLp8 extends BaseTest {
         new BasePage(driver).reportScreenshot("Screenshot "+regulative+" regulative");
 
     }
+    @Test(description = "Check if user is already registered")
+    @Description("User try to register already registered account")
+    @Parameters({"countryCodeNumber"})
+    public void userExist(String countryCodeNumber) throws IOException {
+        /**
+         *navigate to the landing page - driver.get() is triggered from setUp method
+         */
+        AccountRegistrationFullNamePage accountRegistrationFullNamePage = new AccountRegistrationFullNamePage(driver);
+        /**
+         *register new account
+         */
+        accountRegistrationFullNamePage.accountRegistrationFullNamePageMethod("Testq Testa", "test"
+                        + System.currentTimeMillis() + "@mailinator.com",countryCodeNumber + "",
+                "" + System.currentTimeMillis());
+        WebDriverWait wdWait = new WebDriverWait(driver,10);
+        /**
+         *save the email address used during account registration
+         */
+        wdWait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='credetialsBox']//span" +
+                "[@id='loginUserEmail']")));
+        WebElement email = driver.findElement(By.xpath("//div[@class='credetialsBox']//span[@id='loginUserEmail']"));
+        String emailAddress = email.getText();
+        System.out.println(emailAddress);
+        driver.close();
+        /**
+         * navigate to the landing page - driver.get() is triggered from setUp method
+         */
+        baseSetUp("CHROME","114");
+        driver.get("https://www.fortrade.com/minilps/en/fast-execution/");
+        /**
+         * try to register account by using email address from previous registration (already registered email address)
+         */
+        AccountRegistrationFullNamePage accountRegistrationFullNamePage1 = new AccountRegistrationFullNamePage(driver);
+        accountRegistrationFullNamePage1.accountRegistrationFullNamePageMethod("Testq Testa",emailAddress,
+                countryCodeNumber,""+System.currentTimeMillis());
+        /**
+         * check if user exist pop up appears and verify the same
+         */
+        WebDriverWait wait = new WebDriverWait(driver,5);
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//label[@name='UserExistLabel']")));
+        WebElement userExistWindow = driver.findElement(By.xpath("//label[@name='UserExistLabel']"));
+        userExistWindow.isDisplayed();
+        if(userExistWindow.isDisplayed()==true){
+            System.out.println("'It looks like you've already got an account associated with this email/phone. Log in instead or " +
+                    " reset your password if you've forgotten it.' pop up window is displayed ");
+        }
+        //taking screenshot
+        new BasePage(driver).reportScreenshot("User exist window is displayed");
+        tearDown();
+    }
     @Test(description ="Confirm validation messages")
     @Description("Appropriate error messages are triggered if user doesn't insert data")
     public void fieldsValidation() throws IOException {

--- a/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp9.java
+++ b/Fortrade_landing_pages/src/test/java/Tests/RegistrationTestLp9.java
@@ -55,7 +55,55 @@ public class RegistrationTestLp9 extends BaseTest {
         new BasePage(driver).reportScreenshot("Screenshot " + regulative + " regulative");
 
     }
-
+    @Test(description = "Check if user is already registered")
+    @Description("User try to register already registered account")
+    @Parameters({"countryCodeNumber"})
+    public void userExist(String countryCodeNumber) throws IOException {
+        /**
+         * navigate to the landing page - driver.get() is triggered from setUp method
+         */
+        AccountRegistrationPage accountRegistrationPage = new AccountRegistrationPage(driver);
+        /**
+         *register new account
+         */
+        accountRegistrationPage.accountRegistrationMethod("Testq","Testa",
+                "test"+System.currentTimeMillis()+"@mailinator.com",""+countryCodeNumber,
+                ""+System.currentTimeMillis());
+        WebDriverWait wdWait = new WebDriverWait(driver,10);
+        /**
+         *save the email address used during account registration
+         */
+        wdWait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='credetialsBox']//span" +
+                "[@id='loginUserEmail']")));
+        WebElement email = driver.findElement(By.xpath("//div[@class='credetialsBox']//span[@id='loginUserEmail']"));
+        String emailAddress = email.getText();
+        driver.close();
+        /**
+         * navigate to the same landing page in the new window
+         */
+        baseSetUp("CHROME","114");
+        driver.get("https://www.fortrade.com/minilps/en/reg-place-stocks-in-your-future/");
+        /**
+         * try to register account by using email address from previous registration (already registered email address)
+         */
+        AccountRegistrationPage accountRegistrationPage1 = new AccountRegistrationPage(driver);
+        accountRegistrationPage1.accountRegistrationMethod("Testq","Testa",emailAddress,countryCodeNumber,
+                ""+System.currentTimeMillis());
+        /**
+         * check if user exist pop up appears and verify the same
+         */
+        WebDriverWait wait = new WebDriverWait(driver,5);
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//label[@name='UserExistLabel']")));
+        WebElement userExistWindow = driver.findElement(By.xpath("//label[@name='UserExistLabel']"));
+        userExistWindow.isDisplayed();
+        if(userExistWindow.isDisplayed()==true){
+            System.out.println("'It looks like you've already got an account associated with this email/phone. Log in instead or " +
+                    " reset your password if you've forgotten it.' pop up window is displayed ");
+        }
+        //taking screenshot
+        new BasePage(driver).reportScreenshot("User exist window is displayed");
+        tearDown();
+    }
     @Test(description = "Confirm validation messages")
     @Description("Appropriate error messages are triggered if user doesn't insert data")
     public void fieldsValidation() throws IOException {


### PR DESCRIPTION
New test case added - Check if user try to register already registered email (user already registered email address and tries to register account with same email address). If user tries to register new account with same address , popup with appropriate text and links for login and reset your password should appear. Test does not include regulative parameter since from technical side under new regulative user can register account with same email address.